### PR TITLE
Add platform requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
 	name: "swift-raylib",
+	platforms: [
+		.macOS(.v11)
+	],
 	products: [
 		.library(name: "RaylibKit", targets: ["RaylibKit"]),
 	],


### PR DESCRIPTION
Add platform requirement, to prevent error as mentioned in https://github.com/Lancelotbronner/swift-raylib-examples/issues/1