### PR TITLE
Add Wayland and X11 traits

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,20 @@ let package = Package(
 	products: [
 		.library(name: "RaylibKit", targets: ["RaylibKit"]),
 	],
+	traits: [
+		.default(enabledTraits: ["X11"]),
+		"X11",
+		"Wayland",
+	],
 	dependencies: [
-		.package(url: "https://github.com/Lancelotbronner/raylib-build.git", from: "5.5.2"),
+		.package(
+			url: "https://github.com/Lancelotbronner/raylib-build.git",
+			from: "5.5.2",
+			traits: [
+				.trait(name: "Wayland", condition: .when(traits: ["Wayland"])),
+				.trait(name: "X11", condition: .when(traits: ["X11"])),
+			],
+		)
 	],
 	targets: [
 		.target(name: "RaylibKit", dependencies: [


### PR DESCRIPTION
Adds X11 and Wayland traits so raylib-build can be configured.

Doesn't make sense to merge unless https://github.com/Lancelotbronner/raylib-build/pull/2 is also merged.